### PR TITLE
Make GitHub not detect the language of image.fs.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+/image.fs linguist-vendored


### PR DESCRIPTION
Hello,

Please merge this, if you'd like GitHub not to try to detect the language of your `image.fs` file. Currently, it mistakenly believes it's Forth.

Thank you,
Lars Brinkhoff
