### PR TITLE
Support BTv2.1 Secure Simple Pairing and Export SDP record for Windows support

### DIFF
--- a/btnode.h
+++ b/btnode.h
@@ -1,5 +1,6 @@
 /*
  * BluTuNode - Bluetooth sensor/actuator node software
+ * Copyright (c) 2018 Jacob Schmidt
  * Copyright (c) 2011-2012 Paul Sokolovsky
  *
  * BtNode is free software: you can redistribute it and/or modify
@@ -47,6 +48,7 @@ typedef struct BtNodeCommandTask {
     char *buf_ptr;
     struct InputSource *poll_source;
     int poll_period;
+    bdaddr dev_a;
 } BtNodeCommandTask;
 
 /* Periodical poll message */

--- a/btnode.h
+++ b/btnode.h
@@ -49,6 +49,7 @@ typedef struct BtNodeCommandTask {
     struct InputSource *poll_source;
     int poll_period;
     bdaddr dev_a;
+    uint8 rfcomm_channel;
 } BtNodeCommandTask;
 
 /* Periodical poll message */


### PR DESCRIPTION
In attempting to use this project for my own purposes, I found that these changes were helpful in order to get Blutunode to connect to my Windows 10 machine. I have tested this on an HC-06 module, communicating with Blutunode from both a Linux machine (Debian Stretch) and Win10.